### PR TITLE
Added the ability to communicate with a Multiplexed Server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,33 @@ ThriftClient thriftClient = new ThriftClientImpl(() -> Arrays.asList(//
 // get iface and call
 System.out.println(thriftClient.iface(Client.class).echo("hello world."));
 
+// get iface and call to Multiplexed Server
+System.out.println(thriftClient.mpiface(Client.class, "ClientService").echo("hello world."));
+
+
 // get iface with custom hash, the same hash return the same thrift backend server
 System.out.println(thriftClient.iface(Client.class, "hello world".hashCode()).echo(
         "hello world"));
+
+// get mpiface with custom hash, the same hash return the same thrift backend server
+System.out.println(thriftClient.iface(Client.class, "ClientService", "hello world".hashCode()).echo(
+        "hello world"));
+
 
 // customize protocol
 System.out.println(thriftClient.iface(Client.class, TBinaryProtocol::new,
         "hello world".hashCode()).echo("hello world"));
 
+// customize protocol to Multiplexed Server
+System.out.println(thriftClient.mpiface(Client.class, "ClientService", TBinaryProtocol::new,
+        "hello world".hashCode()).echo("hello world"));
+
+
 // customize pool config
 GenericKeyedObjectPoolConfig poolConfig = new GenericKeyedObjectPoolConfig();
 // ... customize pool config here
+
+
 // customize transport, while if you expect pooling the connection, you should use TFrameTransport.
 Function<ThriftServerInfo, TTransport> transportProvider = info -> {
     TSocket socket = new TSocket(info.getHost(), info.getPort());
@@ -54,12 +70,14 @@ ThriftClient customizeThriftClient = new ThriftClientImpl(() -> Arrays.asList(//
         ), new DefaultThriftConnectionPoolImpl(poolConfig, transportProvider));
 customizeThriftClient.iface(Client.class).echo("hello world.");
 
+
 // init a failover thrift client
 ThriftClient failoverThriftClient = new FailoverThriftClientImpl(() -> Arrays.asList(//
         ThriftServerInfo.of("127.0.0.1", 9090), //
         ThriftServerInfo.of("127.0.0.1", 9091) //
         ));
 failoverThriftClient.iface(Client.class).echo("hello world.");
+
 
 // a customize failover client, if the call fail 10 times in 30 seconds, the backend server will be marked as fail for 1 minutes.
 FailoverCheckingStrategy<ThriftServerInfo> failoverCheckingStrategy = new FailoverCheckingStrategy<>(

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 		<dependency>
 			<groupId>org.apache.thrift</groupId>
 			<artifactId>libthrift</artifactId>
-			<version>0.9.2</version>
+			<version>0.9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/src/main/java/com/github/phantomthief/thrift/client/ThriftClient.java
+++ b/src/main/java/com/github/phantomthief/thrift/client/ThriftClient.java
@@ -45,4 +45,35 @@ public interface ThriftClient {
     <X extends TServiceClient> X iface(Class<X> ifaceClass,
             Function<TTransport, TProtocol> protocolProvider, int hash);
 
+    /**
+     * <p>mpiface.</p>
+     *
+     * @param ifaceClass the {@link java.lang.Class} of the TServiceClient.
+     * @param serviceName the {@link java.lang.String} name of the service.
+     * @return a X object.
+     */
+    public <X extends TServiceClient> X mpiface(Class<X> ifaceClass, String serviceName);
+
+    /**
+     * <p>mpiface.</p>
+     *
+     * @param ifaceClass the {@link java.lang.Class} of the TServiceClient.
+     * @param serviceName the {@link java.lang.String} name of the service.
+     * @param hash a int.
+     * @return a X object.
+     */
+    public <X extends TServiceClient> X mpiface(Class<X> ifaceClass, String serviceName, int hash);
+
+    /**
+     * <p>mpiface.</p>
+     *
+     * @param ifaceClass the {@link java.lang.Class} of the TServiceClient.
+     * @param serviceName the {@link java.lang.String} name of the service.
+     * @param protocolProvider a {@link java.util.function.Function} object.
+     * @param hash a int.
+     * @return a X object.
+     */
+    public <X extends TServiceClient> X mpiface(Class<X> ifaceClass, String serviceName,
+            Function<TTransport, TProtocol> protocolProvider, int hash);
+
 }

--- a/src/main/java/com/github/phantomthief/thrift/client/impl/FailoverThriftClientImpl.java
+++ b/src/main/java/com/github/phantomthief/thrift/client/impl/FailoverThriftClientImpl.java
@@ -11,6 +11,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.apache.thrift.TServiceClient;
+import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.TTransport;
 
@@ -19,6 +20,7 @@ import com.github.phantomthief.thrift.client.pool.ThriftConnectionPoolProvider;
 import com.github.phantomthief.thrift.client.pool.ThriftServerInfo;
 import com.github.phantomthief.thrift.client.pool.impl.DefaultThriftConnectionPoolImpl;
 import com.github.phantomthief.thrift.client.utils.FailoverCheckingStrategy;
+import com.github.phantomthief.thrift.client.utils.ThriftClientUtils;
 
 /**
  * <p>
@@ -93,6 +95,25 @@ public class FailoverThriftClientImpl implements ThriftClient {
     public <X extends TServiceClient> X iface(Class<X> ifaceClass,
             Function<TTransport, TProtocol> protocolProvider, int hash) {
         return thriftClient.iface(ifaceClass, protocolProvider, hash);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public <X extends TServiceClient> X mpiface(Class<X> ifaceClass, String serviceName) {
+        return thriftClient.mpiface(ifaceClass, serviceName, ThriftClientUtils.randomNextInt());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public <X extends TServiceClient> X mpiface(Class<X> ifaceClass, String serviceName, int hash) {
+        return thriftClient.mpiface(ifaceClass, serviceName, TBinaryProtocol::new, hash);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public <X extends TServiceClient> X mpiface(Class<X> ifaceClass, String serviceName,
+        Function<TTransport, TProtocol> protocolProvider, int hash) {
+        return thriftClient.mpiface(ifaceClass, serviceName, protocolProvider, hash);
     }
 
     /* (non-Javadoc)

--- a/src/main/java/com/github/phantomthief/thrift/client/impl/ThriftClientImpl.java
+++ b/src/main/java/com/github/phantomthief/thrift/client/impl/ThriftClientImpl.java
@@ -10,6 +10,7 @@ import java.util.function.Supplier;
 
 import org.apache.thrift.TServiceClient;
 import org.apache.thrift.protocol.TCompactProtocol;
+import org.apache.thrift.protocol.TMultiplexedProtocol;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.TTransport;
 
@@ -137,6 +138,44 @@ public class ThriftClientImpl implements ThriftClient {
                 | IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException("fail to create proxy.", e);
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>
+     * mpiface.
+     * </p>
+     */
+    @Override
+    public <X extends TServiceClient> X mpiface(Class<X> ifaceClass, String serviceName) {
+        return mpiface(ifaceClass, serviceName, ThriftClientUtils.randomNextInt());
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>
+     * mpiface.
+     * </p>
+     */
+    @Override
+    public <X extends TServiceClient> X mpiface(Class<X> ifaceClass, String serviceName, int hash) {
+        return mpiface(ifaceClass, serviceName, TCompactProtocol::new, hash);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>
+     * mpiface.
+     * </p>
+     */
+    @Override
+    public <X extends TServiceClient> X mpiface(Class<X> ifaceClass, String serviceName,
+        Function<TTransport, TProtocol> protocolProvider, int hash) {
+        return iface(ifaceClass,
+            protocolProvider.andThen((p) -> new TMultiplexedProtocol(p, serviceName)), hash);
     }
 
 }


### PR DESCRIPTION
In a Multiplexed Server, every Service gets a name. You have to identify
your service calls by that same name, using a TMultiplexedProtocol,
which is a wrapper around TBinaryProtocol or TCompactProtocol.

Three methods were added to the ThriftClient, "mpiface", mirroring the
"iface" methods except there is now a String serviceName parameter.

README.md has been updated to show usage of mpiface methods.